### PR TITLE
fix: Unsafe regex for hostname in example rules

### DIFF
--- a/lib/maid/rules.sample.rb
+++ b/lib/maid/rules.sample.rb
@@ -66,7 +66,7 @@ Maid.rules do
   # NOTE: Currently, only Mac OS X supports `downloaded_from`.
   rule 'Old files downloaded while developing/testing' do
     dir('~/Downloads/*').each do |path|
-      if downloaded_from(path).any? { |u| u.match('http://localhost') || u.match('http://staging.yourcompany.com') } &&
+      if downloaded_from(path).any? { |u| u.match('http://localhost') || u.match('http://staging\.yourcompany\.com') } &&
           1.week.since?(accessed_at(path))
         trash(path)
       end


### PR DESCRIPTION
Close #228