### PR TITLE
ci: Specify prerelease version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           version-file: lib/maid/version.rb
           token: ${{ secrets.MAID_GH_TOKEN }}
           prerelease: true
-          release-as: v0.10.0.pre.1
+          release-as: v0.10.0-alpha.1
       - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Manually specify prerelease version, as `release-please` only understands semver proper (i.e. `-` as a prerelease version separator, not `.`)