### PR TITLE
feat(tools): add option to disable clobbering destination for `#move`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,7 +66,7 @@ Metrics/MethodLength:
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 711
+  Max: 722
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -66,7 +66,7 @@ Metrics/MethodLength:
 # Offense count: 4
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 722
+  Max: 753
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -33,7 +33,8 @@ module Maid::Tools
   #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/')
   #
   # @example Multiple source files
-  #   move(['~/Downloads/foo.zip', '~/Downloads/bar.zip'], '~/Archive/Software/Mac OS X/')
+  #   move(['~/Downloads/foo.zip', '~/Downloads/bar.zip'],
+  #   '~/Archive/Software/Mac OS X/')
   #   move(dir('~/Downloads/*.zip'), '~/Archive/Software/Mac OS X/')
   #
   # @example Overwrite destination file if it already exists
@@ -42,7 +43,8 @@ module Maid::Tools
   # @param sources [String, Array<String>] the paths to the source files to move
   # @param destination [String] path of the directory where to move `sources` to
   # @param [Hash] kwargs the arguments to modify behaviour
-  # @option kwargs [Boolean] :clobber (true) `true` to overwrite destination file if it exists, `false` to skip that file
+  # @option kwargs [Boolean] :clobber (true) `true` to overwrite destination
+  # file if it exists, `false` to skip moving file if it exists
   def move(sources, destination, clobber: true)
     expanded_destination = expand(destination)
 

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -1025,9 +1025,9 @@ module Maid::Tools
   end
 
   # Predicate to tell whether the file should be skipped when moving.
-  # @param source_path [String] the source path
-  # @param destination_dir [String] the destination path
-  # @param clobber [Boolean] `true` to overwrite existing destination path,
+  # @param source_path [String] the path to the source file
+  # @param destination_dir [String] the path to the destination directory
+  # @param clobber [Boolean] `true` to overwrite existing destination file,
   # `false` otherwise
   # @return [Boolean] whether to skip the move
   def skip_move?(source_path, destination_dir, clobber)

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -38,7 +38,13 @@ module Maid::Tools
   #   move(dir('~/Downloads/*.zip'), '~/Archive/Software/Mac OS X/')
   #
   # @example Overwrite destination file if it already exists
-  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/', clobber: true)
+  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/')
+  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/', clobber:
+  #   true)
+  #
+  # @example Skip file if it already exists at destination
+  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/', clobber:
+  #   false)
   #
   # @param sources [String, Array<String>] the paths to the source files to move
   # @param destination [String] path of the directory where to move `sources` to

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -24,31 +24,41 @@ module Maid::Tools
   # For showing deprecation notices
   include Deprecated
 
-  # Move `sources` to a `destination` directory.
+  # Moves `sources` file(s) to a `destination` directory.
   #
   # Movement is only allowed to directories that already exist.  If your
   # intention is to rename, see the `rename` method.
   #
-  # ## Examples
+  # @example Single source file
+  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/')
   #
-  # Single path:
+  # @example Multiple source files
+  #   move(['~/Downloads/foo.zip', '~/Downloads/bar.zip'], '~/Archive/Software/Mac OS X/')
+  #   move(dir('~/Downloads/*.zip'), '~/Archive/Software/Mac OS X/')
   #
-  #     move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/')
+  # @example Overwrite destination file if it already exists
+  #   move('~/Downloads/foo.zip', '~/Archive/Software/Mac OS X/', clobber: true)
   #
-  # Multiple paths:
-  #
-  #     move(['~/Downloads/foo.zip', '~/Downloads/bar.zip'], '~/Archive/Software/Mac OS X/')
-  #     move(dir('~/Downloads/*.zip'), '~/Archive/Software/Mac OS X/')
-  def move(sources, destination)
+  # @param sources [String, Array<String>] the paths to the source files to move
+  # @param destination [String] path of the directory where to move `sources` to
+  # @param [Hash] kwargs the arguments to modify behaviour
+  # @option kwargs [Boolean] :clobber (true) `true` to overwrite destination file if it exists, `false` to skip that file
+  def move(sources, destination, clobber: true)
     expanded_destination = expand(destination)
 
     if File.directory?(expanded_destination)
       expand_all(sources).each do |source|
         dest_file_path = File.join(expanded_destination, File.basename(source))
-        dest_file_exists = File.exist?(dest_file_path)
 
-        if dest_file_exists
-          log("#{File.join(expanded_destination, File.basename(source))} already exists, moving it anyway.")
+        if File.exist?(dest_file_path)
+          log("#{dest_file_path} already exists")
+
+          if clobber
+            log("clobber is true, moving #{File.basename(source)} anyway")
+          else
+            log("clobber is false, skipping move for #{File.basename(source)}")
+            next
+          end
         end
 
         log("move #{sh_escape(source)} #{sh_escape(expanded_destination)}")

--- a/lib/maid/tools.rb
+++ b/lib/maid/tools.rb
@@ -44,6 +44,13 @@ module Maid::Tools
 
     if File.directory?(expanded_destination)
       expand_all(sources).each do |source|
+        dest_file_path = File.join(expanded_destination, File.basename(source))
+        dest_file_exists = File.exist?(dest_file_path)
+
+        if dest_file_exists
+          log("#{File.join(expanded_destination, File.basename(source))} already exists, moving it anyway.")
+        end
+
         log("move #{sh_escape(source)} #{sh_escape(expanded_destination)}")
         FileUtils.mv(source, expanded_destination, **@file_options)
       end

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -73,6 +73,21 @@ module Maid
           @maid.move([@src_file, another_file], @dst_dir)
         end
       end
+
+      context 'when the destination file already exists' do
+        let(:file) { File.expand_path('/tmp/test_file') }
+
+        before do
+          FileUtils.mkdir_p(File.dirname(file))
+          FileUtils.touch(file)
+        end
+
+        it 'logs an info message' do
+          expect(@logger).to receive(:info).with(/already/)
+
+          @maid.move(file, File.dirname(file))
+        end
+      end
     end
 
     describe '#rename' do

--- a/spec/lib/maid/tools_spec.rb
+++ b/spec/lib/maid/tools_spec.rb
@@ -75,17 +75,55 @@ module Maid
       end
 
       context 'when the destination file already exists' do
-        let(:file) { File.expand_path('/tmp/test_file') }
+        let(:src_file) { '/tmp/src/test_file' }
+        let(:dst_dir) { '/tmp/dest/' }
+        let(:dst_file) { File.join(dst_dir, File.basename(src_file)) }
+        let(:maid) { Maid.new(logger: @logger) }
 
         before do
-          FileUtils.mkdir_p(File.dirname(file))
-          FileUtils.touch(file)
+          FileUtils.mkdir_p(File.dirname(src_file))
+          FileUtils.mkdir_p(dst_dir)
+          FileUtils.touch(src_file)
+          FileUtils.touch(dst_file)
         end
 
-        it 'logs an info message' do
-          expect(@logger).to receive(:info).with(/already/)
+        after do
+          FileUtils.rm_rf([src_file, dst_file])
+        end
 
-          @maid.move(file, File.dirname(file))
+        context 'by default' do
+          let!(:original_mtime) { File.stat(dst_file).mtime }
+
+          before do
+            maid.move(src_file, dst_dir)
+          end
+
+          it 'logs an info message' do
+            expect(@logger).to have_received(:info).with(/already/)
+            expect(@logger).to have_received(:info).with(/anyway/)
+            expect(@logger).not_to have_received(:info).with(/skipping/)
+          end
+
+          it 'overwrites destination' do
+            expect(File.stat(dst_file).mtime).not_to eq(original_mtime)
+          end
+        end
+
+        context 'when clobber: false' do
+          let!(:original_mtime) { File.stat(dst_file).mtime }
+
+          before do
+            maid.move(src_file, dst_dir, clobber: false)
+          end
+
+          it 'logs an info message' do
+            expect(@logger).not_to have_received(:info).with(/anyway/)
+            expect(@logger).to have_received(:info).with(/skipping/)
+          end
+
+          it "doesn't overwrite the destination file" do
+            expect(File.stat(dst_file).mtime).to eq(original_mtime)
+          end
         end
       end
     end


### PR DESCRIPTION
Show a message instead of bailing on the move by default:
- Unix's `mv` [will overwrite by default](https://github.com/wertarbyte/coreutils/blob/f70c7b785b93dd436788d34827b209453157a6f2/src/mv.c#L303)
- the user might just want to update the timestamps
- short of throwing, the user might never notice anyway (and throwing is
  unnecessary in this case IMO)
- this is how `#move` was behaving until now, bailing will break some rules

Add a `clobber` option to toggle overwriting existing files at destination.

Close #59