### PR TITLE
build(docker): add ruby-2.7 container

### DIFF
--- a/script/docker-test-27
+++ b/script/docker-test-27
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Run RSpec in a docker container, to avoid mistakenly writing to the live
+# filesystem while developing.
+docker rm -f maid-dev
+docker build -t maid-dev:2.7 .
+docker run -it --rm --name maid-dev --mount type=bind,src="$(pwd)",target=/usr/src/app maid-dev:2.7 bash -c 'bundle exec guard'


### PR DESCRIPTION
Ruby 2.7 has small differences vs Ruby 3, running the specs in a
ruby-2.7 container is useful for fixing failing tests on CI.

- [x] Update instructions at https://github.com/maid/maid/wiki/Contributing#use-docker-or-vagrant