### PR TITLE
build(rake): Add tasks to run Guard in Docker

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -28,6 +28,7 @@ end
 guard :rubocop, cli: ['--autocorrect', '--display-cop-names'] do
   watch('Gemfile')
   watch('Vagrantfile')
+  watch('Rakefile')
   watch(%r{^(?!node_modules/).+\.rb$})
   watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ Maid::Rake::Task.new(:clean) do
   trash('tmp')
 end
 
-namespace :spec do
+namespace :guard do
   default_target_ruby_version = File.read('Dockerfile').match(/^FROM ruby:(.*)$/)[1]
 
   desc "Run Guard and RSpec in a Docker container (ruby-#{default_target_ruby_version})"

--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,12 @@ end
 namespace :guard do
   default_target_ruby_version = File.read('Dockerfile').match(/^FROM ruby:(.*)$/)[1]
 
-  desc "Run Guard and RSpec in a Docker container (ruby-#{default_target_ruby_version})"
+  desc "Run Guard in a Docker container (ruby-#{default_target_ruby_version})"
   task :docker do
     system('./script/docker-test')
   end
 
-  desc 'Run Guard and RSpec in a Docker container (ruby-2.7)'
+  desc 'Run Guard in a Docker container (ruby-2.7)'
   task :docker27 do
     system('./script/docker-test-27')
   end

--- a/Rakefile
+++ b/Rakefile
@@ -26,16 +26,16 @@ Maid::Rake::Task.new(:clean) do
   trash('tmp')
 end
 
-namespace :docker do
+namespace :spec do
   default_target_ruby_version = File.read('Dockerfile').match(/^FROM ruby:(.*)$/)[1]
 
   desc "Run Guard and RSpec in a Docker container (ruby-#{default_target_ruby_version})"
-  task :default do
+  task :docker do
     system('./script/docker-test')
   end
 
   desc 'Run Guard and RSpec in a Docker container (ruby-2.7)'
-  task :'27' do
+  task :docker27 do
     system('./script/docker-test-27')
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,17 @@ Maid::Rake::Task.new(:clean) do
   trash('pkg')
   trash('tmp')
 end
+
+namespace :docker do
+  default_target_ruby_version = File.read('Dockerfile').match(/^FROM ruby:(.*)$/)[1]
+
+  desc "Run Guard and RSpec in a Docker container (ruby-#{default_target_ruby_version})"
+  task :default do
+    system('./script/docker-test')
+  end
+
+  desc 'Run Guard and RSpec in a Docker container (ruby-2.7)'
+  task :'27' do
+    system('./script/docker-test-27')
+  end
+end

--- a/spec/lib/maid/maid_spec.rb
+++ b/spec/lib/maid/maid_spec.rb
@@ -262,7 +262,7 @@ module Maid
             # Suppressing the exception is fine, because we just want to test
             # that the message is logged when it throws and the test above
             # checks that the exception is raised.
-          rescue StandardError # rubocop:disable RSpec/SuppressedException
+          rescue StandardError # rubocop:disable Lint/SuppressedException
           end
 
           expect(File.read(logfile)).to match(/file.*exist/)


### PR DESCRIPTION
```
$ rake --tasks
[...]
rake guard:docker     # Run Guard in a Docker container (ruby-3.2)
rake guard:docker27   # Run Guard in a Docker container (ruby-2.7)
[...]
```