### PR TITLE
Add support for longer durations (months, quarters, years)

### DIFF
--- a/lib/maid/numeric_extensions.rb
+++ b/lib/maid/numeric_extensions.rb
@@ -80,6 +80,23 @@ module Maid::NumericExtensions
     ### Maid additions ###
     ######################
 
+    # TODO: Import ActiveSupport directly: https://github.com/maid/maid/issues/81
+
+    def months
+      self * 30.days
+    end
+    alias month months
+
+    def quarters
+      self * 13.weeks
+    end
+    alias quarter quarters
+
+    def years
+      self * 365.days
+    end
+    alias year years
+
     # TODO: find a better place for these to live?
 
     # Reads well in a case like:


### PR DESCRIPTION
As the Ruby ecosystem is unfamiliar to me, I didn't want to go down the rabbit hole of checking if #81 would be more feasible.

Of course, `months` is imprecise, but I don't think that there's much that we can do about that anyway.

Fixes #79 