### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Upload coverage to Code Climate
 
 on:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint
 
 on:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/maid/maid/security/code-scanning/4](https://github.com/maid/maid/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/lint.yml`. Since neither job requires write access to the repository, the minimal required permission is `contents: read`. This block can be added at the root level of the workflow, which will apply to all jobs unless overridden. The change should be made at the top of the file, immediately after the `name` field and before the `on` field. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
